### PR TITLE
Update docker-compose.yml to create todos database

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Feature:
     ```
     cp .env.sample .env
     ```
-2. Start mysql and create database.
+2. Start mysql and create database. [^mac]
+   [^mac]: Regular MySQL Docker images are not built for the new Mac ARM processors. To use a MySQL docker image that works on ARM, you may update [docker-compose.yml#L5](docker-compose.yml#L5) to use a different one, such as `image: "arm64v8/mysql:latest"` instead of `image: "mysql:latest"`. See [Dockerhub arm64v8/mysql](https://hub.docker.com/r/arm64v8/mysql) for more details. 
     ```
     docker-compose up -d
     ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - ${MYSQL_PORT}:3306
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_DATABASE: todos


### PR DESCRIPTION
When I tried to set up this project, I encountered an issue with the `rel migrate` command. There wasn't a todos database, although rel was trying to use one as defined in the .env file.

```bash
❯ rel migrate
panic: Error 1049 (42000): Unknown database 'todos'

goroutine 1 [running]:
github.com/go-rel/mysql.check(...)
```

To fix this, simply need to add `MYSQL_DATABASE: todos` to the docker-compose.yml file.

```bash
❯ rel migrate
Running: migrate 20202806225100 create table todos, create index order on todos
=> Done: migrate 20202806225100 create table todos, create index order on todos in 20.1125ms
Running: migrate 20203006230600 create table scores
=> Done: migrate 20203006230600 create table scores in 12.681042ms
Running: migrate 20203006230700 create table points
=> Done: migrate 20203006230700 create table points in 15.450167ms
```

Modifying the docker-compose.yml to create the database is consistent with https://github.com/Fs02/go-todo-backend/blob/master/docker-compose.yml, which specifies the POSTGRES_DB such that the database is added to the container as it's created.

Incidentally, to allow running on Mac, I had to change the image from `mysql:latest` to:

```docker
    image: 'arm64v8/mysql:latest'
```

Would this be something to mention in the readme?
